### PR TITLE
Make parsing for parties for small claims less brittle

### DIFF
--- a/lib/oscn_scraper/parsers/parties.rb
+++ b/lib/oscn_scraper/parsers/parties.rb
@@ -46,10 +46,9 @@ module OscnScraper
       end
 
       def build_parties_text(element)
-        parts = element.text.split(",\r\n")
         parties[:parties] << {
-          name: parts[0]&.strip,
-          party_type: parts[1]&.strip
+          name: element.xpath('//span[@class="parties_partyname"]').first.text&.strip,
+          party_type: element.xpath('//span[@class="parties_type"]').first.text&.strip
         }
       end
     end

--- a/lib/oscn_scraper/parsers/parties.rb
+++ b/lib/oscn_scraper/parsers/parties.rb
@@ -26,7 +26,7 @@ module OscnScraper
         return parties if parties_html.blank?
 
         if parties_html.css('a').empty?
-          parties_html.css('p').children.each do |element|
+          parties_html.xpath('//span[@class="parties_party"]').each do |element|
             build_parties_text(element) unless element.text.blank?
           end
         else
@@ -47,8 +47,8 @@ module OscnScraper
 
       def build_parties_text(element)
         parties[:parties] << {
-          name: element.xpath('//span[@class="parties_partyname"]').first.text&.strip,
-          party_type: element.xpath('//span[@class="parties_type"]').first.text&.strip
+          name: element.xpath('span[@class="parties_partyname"]').first.text&.strip,
+          party_type: element.xpath('span[@class="parties_type"]').first.text&.strip
         }
       end
     end

--- a/spec/fixtures/parsers/parties/no-link.html
+++ b/spec/fixtures/parsers/parties/no-link.html
@@ -1,0 +1,7 @@
+<h2 class="section party">Parties</h2>
+        <p><span class="parties_party"><span class="parties_partyname">Cavalry SPV I, LLC</span>,
+
+<span class="parties_type">Plaintiff</span></span><br><span class="parties_party"><span class="parties_partyname">Paul,&nbsp; John&nbsp; O</span>,
+
+<span class="parties_type">Defendant</span></span><br> &nbsp;
+        </p>

--- a/spec/fixtures/small-claims-example.html
+++ b/spec/fixtures/small-claims-example.html
@@ -314,7 +314,7 @@
                 </div>
                 <div class="right">
                     <ul>
-                        <!--<li><a href="">e-filing</a></li>-->
+                        <li><a href="https://efile.oscn.net">e-filing</a></li>
                         <li><a href="https://pay.oscn.net/epayments/">e-payments</a></li>
                         <li><a href="/jobs/">Careers</a></li>
                         <!-- <li class="site-search no-border">
@@ -582,11 +582,11 @@
             "court": "OKLAHOMA"
         }
     </script><h2 class="section party">Parties</h2>
-        <p>Citibank, N.A.,
+        <p><span class="parties_party"><span class="parties_partyname">Citibank, N.A.</span>,
 
-            Plaintiff<br>Lillge,&nbsp; Ashley&nbsp; R,
+<span class="parties_type">Plaintiff</span></span><br><span class="parties_party"><span class="parties_partyname">Lillge,&nbsp; Ashley&nbsp; R</span>,
 
-            Defendant<br> &nbsp;
+<span class="parties_type">Defendant</span></span><br> &nbsp;
         </p>
         <h2 class="section attorneys">Attorneys</h2>
         <table width="100%">

--- a/spec/parsers/parties_spec.rb
+++ b/spec/parsers/parties_spec.rb
@@ -17,5 +17,7 @@ RSpec.describe OscnScraper::Parsers::Parties do
     expect(data[:parties].count).to eq 2
     expect(data[:parties].first[:name]).to eq('Cavalry SPV I, LLC')
     expect(data[:parties].first[:party_type]).to eq('Plaintiff')
+    expect(data[:parties].last[:name]).to eq('Paul,  John  O')
+    expect(data[:parties].last[:party_type]).to eq('Defendant')
   end
 end

--- a/spec/parsers/parties_spec.rb
+++ b/spec/parsers/parties_spec.rb
@@ -8,4 +8,14 @@ RSpec.describe OscnScraper::Parsers::Parties do
     expect(data[:parties].first[:link]).to eq 'GetPartyRecord.aspx?db=oklahoma&cn=CF-2024-3682&id=19656360'
     expect(data[:parties].first[:party_type]).to eq 'Defendant'
   end
+
+  it 'parses the parties when there are no links' do
+    fixture_path = 'spec/fixtures/parsers/parties/no-link.html'
+    parsed_html = load_and_parse_fixture(fixture_path)
+    data = described_class.parse(parsed_html)
+
+    expect(data[:parties].count).to eq 2
+    expect(data[:parties].first[:name]).to eq ("Cavalry SPV I, LLC")
+    expect(data[:parties].first[:party_type]).to eq ("Plaintiff")
+  end
 end

--- a/spec/parsers/parties_spec.rb
+++ b/spec/parsers/parties_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe OscnScraper::Parsers::Parties do
     data = described_class.parse(parsed_html)
 
     expect(data[:parties].count).to eq 2
-    expect(data[:parties].first[:name]).to eq ("Cavalry SPV I, LLC")
-    expect(data[:parties].first[:party_type]).to eq ("Plaintiff")
+    expect(data[:parties].first[:name]).to eq('Cavalry SPV I, LLC')
+    expect(data[:parties].first[:party_type]).to eq('Plaintiff')
   end
 end


### PR DESCRIPTION
## Description
The parsing of small claims cases depended on "\r" character which is system specific etc and brittle.
Since the original code was written the associated HTML has been updated to be targetable using classes.

## How to test
[ ] ensure that parties for new small claims cases are parsed correctly

## Checklist
